### PR TITLE
ch(restructure-dashboard) Separated admin and user dashboards [Finishes #164329776]

### DIFF
--- a/UI/admin.html
+++ b/UI/admin.html
@@ -18,7 +18,10 @@
                 <li>
                     <a href="index.html"><i class="fas fa-arrow-left"></i></a>
                 </li>
-                <li class="middle">Dashboard</li>
+
+
+                <li class="middle">Administrator Dashboard</li>
+
 
                 <div class="right-nav">
                     <li>
@@ -34,93 +37,77 @@
         <a href="#" class="tablink" onclick="openLink(event, 'offices')"><i class="fas fa-landmark"></i> Offices</a>
         <a href="#" class="tablink" onclick="openLink(event, 'politicians')"><i class="fas fa-user-secret"></i>
             Politicians</a>
-        <a href="#" class="tablink" onclick="openLink(event, 'vote')"><i class="fas fa-vote-yea"></i> Vote!</a>
+        <a href="#" class="tablink" onclick="openLink(event, 'nomination')"><i class="fas fa-thumbs-up"></i>
+            Requests</a>
         <a href="#" class="tablink" onclick="openLink(event, 'results')"><i class="fas fa-poll"></i> Results</a>
     </div>
 
     <div class="main">
         <div id="parties" class="tab-content">
             <h1>Registered Political Parties</h1>
+            <a href="create-party.html"><button>Create Party</button></a>
             <table>
                 <tr>
                     <th>Party ID</th>
                     <th>Party Name</th>
                     <th>Party Logo</th>
+                    <th>Manage</th>
                 </tr>
                 <tr>
                     <td>1</td>
                     <td>Democrat</td>
                     <td><img src="img/logos/donkey.jpg" alt="Donkey"></td>
+                    <td><a href="edit-party.html"><button>Edit</button></a><a
+                            href="success.html"><button>Delete</button></a></td>
                 </tr>
                 <tr>
                     <td>2</td>
                     <td>Republican</td>
                     <td><img src="img/logos/elephant.jpg" alt="Elephant"></td>
+                    <td><a href="edit-party.html"><button>Edit</button></a></a><a
+                            href="success.html"><button>Delete</button></a></td>
                 </tr>
                 <tr>
                     <td>3</td>
                     <td>Libertarian Party</td>
                     <td><img src="img/logos/cockerel.jpg" alt="Cockerel"></td>
+                    <td><a href="edit-party.html"><button>Edit</button></a></a><a
+                            href="success.html"><button>Delete</button></a></td>
                 </tr>
             </table>
-        </div>
-        <div id="vote" class="tab-content">
-            <h1>Ballot Booth</h1>
-            <p>Vote for your favourite Candidate here</p>
-            <div class="radiocontainer">
-                <div class="custom-select">
-                    <label>Presidential</label>
-                    <select>
-                        <option value="0">Choose</option>
-                        <option value="1">Elton John</option>
-                        <option value="2">Mit Romney</option>
-                        <option value="3">Donald Trump</option>
-                    </select>
-                </div>
-                <div class="custom-select">
-                    <label>Gubernatorial</label>
-                    <select>
-                        <option value="0">Choose:</option>
-                        <option value="1">Mariah Carey</option>
-                        <option value="2">Michael Bolton</option>
-                        <option value="3">Wayne Rooney</option>
-                    </select>
-                </div>
-                <div class="custom-select">
-                    <label>National Assembly </label> </label>
-                    <select>
-                        <option value="0">Choose:</option>
-                        <option value="1">Moh Salah</option>
-                        <option value="2">Titus Bramble</option>
-                        <option value="3">Olivier Giroud</option>
-                    </select>
-                </div>
-                <a href="user-profile.html"><button>Submit Votes</button></a>
-            </div>
         </div>
 
         <div id="offices" class="tab-content" style="display:none">
             <h1>Elective Offices</h1>
+            <a href="create-office.html"><button>Create Office</button></a>
             <table>
                 <tr>
                     <th>Office ID</th>
                     <th>Office Name</th>
                     <th>Description</th>
+                    <th>Manage</th>
                 </tr>
                 <tr>
                     <td>1</td>
                     <td>President</td>
                     <td>This is the Leader of Government and the Head of State</td>
+                    <td><a href="edit-party.html"><button>Edit</button></a><a
+                            href="success.html"><button>Delete</button></a></td>
                 </tr>
                 <tr>
                     <td>2</td>
                     <td>Governor</td>
                     <td>This is the Leader of County Government, which is a devolved unit of Governance</td>
+                    <td><a href="edit-party.html"><button>Edit</button></a><a
+                            href="success.html"><button>Delete</button></a></td>
                 </tr>
                 <tr>
                     <td>3</td>
                     <td>Member of National Assembly</td>
                     <td>This is the representative of a Constituency at the National Assembly</td>
+                    <td><a href="edit-party.html"><button>Edit</button></a><a
+                            href="success.html"><button>Delete</button></a></td>
+                </tr>
             </table>
         </div>
 
@@ -198,6 +185,117 @@
                 </tr>
             </table>
             <p>National Assembly Nominees</p>
+            <table>
+                <tr>
+                    <th>Politician ID</th>
+                    <th>Avatar</th>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                    <th>Elective Office</th>
+                    <th>Party</th>
+                </tr>
+
+                <tr>
+                    <td>1</td>
+                    <td><img src="img/avatars/man.png" alt="Mo Salah"></td>
+                    <td>Mo</td>
+                    <td>Salah</td>
+                    <td>National Assembly</td>
+                    <td>Republican</td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td><img src="img/avatars/man.png" alt="Titus Bramble"></td>
+                    <td>Titus</td>
+                    <td>Bramble</td>
+                    <td>National Assembly</td>
+                    <td>Democrat</td>
+                </tr>
+                <tr>
+                    <td>3</td>
+                    <td><img src="img/avatars/man.png" alt="Olivier Giroud"></td>
+                    <td>Olivier</td>
+                    <td>Giroud</td>
+                    <td>National Assembly</td>
+                    <td>Libertarian</td>
+                </tr>
+            </table>
+        </div>
+
+        <div id="nomination" class="tab-content" style="display:none">
+            <h1>Nomination Requests</h1>
+            <p>Presidential Requests</p>
+            <table>
+                <tr>
+                    <th>Politician ID</th>
+                    <th>Avatar</th>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                    <th>Elective Office</th>
+                    <th>Party</th>
+                </tr>
+                <tr>
+                    <td>1</td>
+                    <td><img src="img/avatars/woman.png" alt="Mit Romney"></td>
+                    <td>Hillary</td>
+                    <td>Clinton</td>
+                    <td>President</td>
+                    <td>Democrat</td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td><img src="img/avatars/man.png" alt="Donald Trump"></td>
+                    <td>Donald</td>
+                    <td>Trump</td>
+                    <td>President</td>
+                    <td>Republican</td>
+                </tr>
+                <tr>
+                    <td>3</td>
+                    <td><img src="img/avatars/man.png" alt="George Washington"></td>
+                    <td>George</td>
+                    <td>Washington</td>
+                    <td>President</td>
+                    <td>Libertarian Party</td>
+                </tr>
+            </table>
+            <p>Gubernatorial Requests</p>
+            <table>
+                <tr>
+                    <th>Politician ID</th>
+                    <th>Avatar</th>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                    <th>Elective Office</th>
+                    <th>Party</th>
+                </tr>
+
+                <tr>
+                    <td>1</td>
+                    <td><img src="img/avatars/man.png" alt="Wayne Rooney"></td>
+                    <td>Wayne</td>
+                    <td>Rooney</td>
+                    <td>Gubernatorial</td>
+                    <td>Republican</td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td><img src="img/avatars/woman.png" alt="Mariah Carey"></td>
+                    <td>Mariah</td>
+                    <td>Carey</td>
+                    <td>Gubernatorial</td>
+                    <td>Democrat</td>
+                </tr>
+                <tr>
+                    <td>3</td>
+                    <td><img src="img/avatars/man.png" alt="George Washington"></td>
+                    <td>Michael</td>
+                    <td>Bolton</td>
+                    <td>Gubernatorial</td>
+                    <td>Libertarian</td>
+                </tr>
+            </table>
+            <p>National Assembly Requests</p>
             <table>
                 <tr>
                     <th>Politician ID</th>

--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -32,6 +32,12 @@ body {
     float: right;
 }
 
+.middle{
+    color: white;
+    text-align: center;
+    font-size: 30px;
+    margin-left: 35%;
+}
 .center-nav {
     text-align: center;
 }

--- a/UI/index.html
+++ b/UI/index.html
@@ -7,7 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Politico</title>
     <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.0/css/all.css" integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.0/css/all.css"
+        integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ" crossorigin="anonymous">
 </head>
 
 <body>
@@ -19,10 +20,10 @@
                 </li>
                 <div class="right-nav">
                     <li>
-                        <a href="sign-up.html"><i class="fas fa-user-plus"></i>  Sign Up!</a>
+                        <a href="sign-up.html"><i class="fas fa-user-plus"></i> Sign Up!</a>
                     </li>
                     <li>
-                        <a href="sign-in.html"><i class="fas fa-sign-in-alt"></i>  Sign In</a>
+                        <a href="login.html"><i class="fas fa-sign-in-alt"></i> Sign In</a>
                     </li>
                 </div>
             </ul>

--- a/UI/js/login.js
+++ b/UI/js/login.js
@@ -22,7 +22,11 @@ function userLogin(e) {
         .then((result) => {
             if (result.status == 201) {
                 setToken(result)
-                window.location.href = 'dashboard.html'
+                if (result.body.data[0].user.isAdmin == true) {
+                    window.location.href = 'admin.html'
+                } else {
+                    window.location.href = 'dashboard.html'
+                }
             } else if (result.status == 400) {
                 document.getElementById('error-display').innerHTML = result.body.message + "!"
                 document.getElementById('error-display').style.display = "block"


### PR DESCRIPTION
### What does this PR do?
Separates dashboard into distinctive admin and user dashboards

### Description of tasks to be completed
-  Create ```admin.html``` file for admin dashboard
-  Edit ```dashboard.html``` file for user-dashboard
- Edit ```login.js``` to include dashboard switching logic depending on user's ```isAdmin``` status
### How should this be manually tested?
- Visit https://kipruto.github.io/politico-ui/UI/login.html
- Login using your credentials and you will be routed to your dashboard depending on your user privileges
### Relevant PT stories
#164329776
### Screenshots
Administrator Dashboard
![admins](https://user-images.githubusercontent.com/4771875/53646109-708ccc00-3c4b-11e9-91b1-dd9019891c0c.png)

User Dashboard
![dashboard](https://user-images.githubusercontent.com/4771875/53646161-8d290400-3c4b-11e9-9ca1-db0542b2877d.png)
